### PR TITLE
Исправляем путь у бейджа со статусом тестов

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Tests](https://github.com/yandex-praktikum/react-mesto-api-full-gha/actions/workflows/tests.yml/badge.svg)](https://github.com/yandex-praktikum/react-mesto-api-full-gha/actions/workflows/tests.yml)
+[![Статус тестов](../../actions/workflows/tests.yml/badge.svg)](../../actions/workflows/tests.yml)
+
 # react-mesto-api-full
 Репозиторий для приложения проекта `Mesto`, включающий фронтенд и бэкенд части приложения со следующими возможностями: авторизации и регистрации пользователей, операции с карточками и пользователями. Бэкенд расположите в директории `backend/`, а фронтенд - в `frontend/`. 
   


### PR DESCRIPTION
Вместо абсолютной ссылки на шаблонный репозиторий используем относительный, благодаря чему бейдж отражает корректный статус тестов в студенческих репо